### PR TITLE
docs: sync package name in README with package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ts-analyze-trace
+# @amcasey/ts-analyze-trace
 Tool for analyzing the output of `tsc --generateTrace` automatically, rather than following the steps [here](https://github.com/microsoft/TypeScript/wiki/Performance-Tracing).
 
 Note: The goal is to identify clear-cut hot-spots and provide enough context to extract a small repro.
@@ -6,7 +6,7 @@ The repro can then be used as the basis of a bug report or a starting point for 
 
 ## Usage
 
-First, build your project with `--generateTrace traceDir`.  Then, run `npx ts-analyze-trace traceDir` to see a sorted list of compilation hot-spots.
+First, build your project with `--generateTrace traceDir`.  Then, run `npx @amcasey/ts-analyze-trace traceDir` to see a sorted list of compilation hot-spots.
 
 ## Extras
 


### PR DESCRIPTION
The prefix `@amcasey/` is missing from the `npx` command. Also probably should be in the package name at the top of the README file.