### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The repro can then be used as the basis of a bug report or a starting point for 
 
 ## Usage
 
-First, build your project with `--generateTrace traceDir`.  Then, run `npx ts-analyze-trace traceDir` to see a sorted list of compilation hot-spots.
+First, build your project with `--generateTrace traceDir`.  Then, run `npx @amcasey/ts-analyze-trace traceDir` to see a sorted list of compilation hot-spots.
 
 ## Extras
 


### PR DESCRIPTION
When running as instructed we get the following error:

<img width="601" alt="CleanShot 2022-01-05 at 16 40 04@2x" src="https://user-images.githubusercontent.com/284515/148278567-1609cc79-fc3e-4933-b07e-5467f940c6b8.png">

This PR fixes the instruction of the README by changing to the correct [package name `@amcasey/ts-analyze-trace`](https://github.com/amcasey/ts-analyze-trace/blob/main/package.json#L2).